### PR TITLE
Python3.8 support

### DIFF
--- a/pyhelm3/client.py
+++ b/pyhelm3/client.py
@@ -96,7 +96,7 @@ class Client:
         devel: bool = False,
         repo: t.Optional[str] = None,
         version: t.Optional[str] = None
-    ) -> contextlib.AbstractAsyncContextManager[pathlib.Path]:
+    ) -> t.AsyncGenerator[Chart, None]:
         """
         Context manager that pulls the specified chart and yields a chart object
         whose ref is the unpacked chart directory.

--- a/pyhelm3/models.py
+++ b/pyhelm3/models.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 import pathlib
 import typing as t
+import annotated_types as at
 
 import yaml
 
@@ -59,8 +60,8 @@ def validate_str_as(validate_type):
 
 
 #: Annotated string types for URLs
-AnyUrl = t.Annotated[str, AfterValidator(validate_str_as(PydanticAnyUrl))]
-HttpUrl = t.Annotated[str, AfterValidator(validate_str_as(PydanticHttpUrl))]
+AnyUrl = at.Annotated[str, AfterValidator(validate_str_as(PydanticAnyUrl))]
+HttpUrl = at.Annotated[str, AfterValidator(validate_str_as(PydanticHttpUrl))]
 
 
 class ChartDependency(BaseModel):

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,5 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    pydantic
+    pydantic>=2.0.0
     pyyaml


### PR DESCRIPTION
Pydantic2 supports as low as python3.8, but some of the current type hints are only supported after python3.9. This PR aims to make minimalist changes to support python3.8.

Tested using `client.install_or_upgrade_release` on python 3.8.10 and 3.10.13.