### PR TITLE
Add support to kube-apiserver and kube-token options to authenticate: #20

### DIFF
--- a/pyhelm3/client.py
+++ b/pyhelm3/client.py
@@ -54,6 +54,8 @@ class Client:
         insecure_skip_tls_verify: bool = False,
         kubeconfig: t.Optional[pathlib.Path] = None,
         kubecontext: t.Optional[str] = None,
+        kubeapiserver: t.Optional[str] = None,
+        kubetoken: t.Optional[str] = None,
         unpack_directory: t.Optional[str] = None
     ):
         self._command = command or Command(
@@ -63,6 +65,8 @@ class Client:
             insecure_skip_tls_verify = insecure_skip_tls_verify,
             kubeconfig = kubeconfig,
             kubecontext = kubecontext,
+            kubeapiserver = kubeapiserver,
+            kubetoken = kubetoken,
             unpack_directory = unpack_directory
         )
 

--- a/pyhelm3/command.py
+++ b/pyhelm3/command.py
@@ -145,6 +145,8 @@ class Command:
         insecure_skip_tls_verify: bool = False,
         kubeconfig: t.Optional[pathlib.Path] = None,
         kubecontext: t.Optional[str] = None,
+        kubeapiserver: t.Optional[str] = None,
+        kubetoken: t.Optional[str] = None,
         unpack_directory: t.Optional[str] = None
     ):
         self._logger = logging.getLogger(__name__)
@@ -154,6 +156,8 @@ class Command:
         self._insecure_skip_tls_verify = insecure_skip_tls_verify
         self._kubeconfig = kubeconfig
         self._kubecontext = kubecontext
+        self._kubeapiserver = kubeapiserver
+        self._kubetoken = kubetoken
         self._unpack_directory = unpack_directory
 
     def _log_format(self, argument):
@@ -174,6 +178,10 @@ class Command:
             command.extend(["--kubeconfig", self._kubeconfig])
         if self._kubecontext:
             command.extend(["--kube-context", self._kubecontext])
+        if self._kubeapiserver:
+            command.extend(["--kube-apiserver", self._kubeapiserver])
+        if self._kubetoken:
+            command.extend(["--kube-token", self._kubetoken])
         # The command must be made up of str and bytes, so convert anything that isn't
         shell_formatted_command = shlex.join(
             part if isinstance(part, (str, bytes)) else str(part)

--- a/pyhelm3/command.py
+++ b/pyhelm3/command.py
@@ -182,6 +182,8 @@ class Command:
             command.extend(["--kube-apiserver", self._kubeapiserver])
         if self._kubetoken:
             command.extend(["--kube-token", self._kubetoken])
+        if self._insecure_skip_tls_verify:
+            command.append("--kube-insecure-skip-tls-verify")
         # The command must be made up of str and bytes, so convert anything that isn't
         shell_formatted_command = shlex.join(
             part if isinstance(part, (str, bytes)) else str(part)
@@ -553,8 +555,6 @@ class Command:
             command.append("--dry-run")
         if force:
             command.append("--force")
-        if self._insecure_skip_tls_verify:
-            command.append("--insecure-skip-tls-verify")
         if namespace:
             command.extend(["--namespace", namespace])
         if no_hooks:
@@ -635,8 +635,6 @@ class Command:
         command = ["pull", chart_ref, "--destination", destination, "--untar"]
         if devel:
             command.append("--devel")
-        if self._insecure_skip_tls_verify:
-            command.append("--insecure-skip-tls-verify")
         if repo:
             command.extend(["--repo", repo])
         if version:
@@ -657,8 +655,6 @@ class Command:
         Returns the new repo list on success.
         """
         command = ["repo", "add", name, url, "--force-update"]
-        if self._insecure_skip_tls_verify:
-            command.append("--insecure-skip-tls-verify")
         await self.run(command)
 
     async def repo_update(self, *names: str):
@@ -763,8 +759,6 @@ class Command:
         command = ["show", "chart", chart_ref]
         if devel:
             command.append("--devel")
-        if self._insecure_skip_tls_verify:
-            command.append("--insecure-skip-tls-verify")
         if repo:
             command.extend(["--repo", repo])
         if version:
@@ -788,8 +782,6 @@ class Command:
         # command = ["show", "crds", chart_ref]
         # if devel:
         #     command.append("--devel")
-        # if self._insecure_skip_tls_verify:
-        #     command.append("--insecure-skip-tls-verify")
         # if repo:
         #     command.extend(["--repo", repo])
         # if version:
@@ -848,8 +840,6 @@ class Command:
         command = ["show", "readme", chart_ref]
         if devel:
             command.append("--devel")
-        if self._insecure_skip_tls_verify:
-            command.append("--insecure-skip-tls-verify")
         if repo:
             command.extend(["--repo", repo])
         if version:
@@ -870,8 +860,6 @@ class Command:
         command = ["show", "values", chart_ref]
         if devel:
             command.append("--devel")
-        if self._insecure_skip_tls_verify:
-            command.append("--insecure-skip-tls-verify")
         if repo:
             command.extend(["--repo", repo])
         if version:
@@ -922,8 +910,6 @@ class Command:
         ]
         if devel:
             command.append("--devel")
-        if self._insecure_skip_tls_verify:
-            command.append("--insecure-skip-tls-verify")
         if is_upgrade:
             command.append("--is-upgrade")
         if namespace:


### PR DESCRIPTION
Add support to kube-apiserver and kube-token options to authenticate: #20
And move the "_insecure_skip_tls_verify" option to the general run command and change the command option to the `--kube-insecure-skip-tls-verify`
