### PR TITLE
Feature: Add debug flag to helm commands

### DIFF
--- a/pyhelm3/command.py
+++ b/pyhelm3/command.py
@@ -350,6 +350,7 @@ class Command:
         # The number of lines of context to show around each diff
         context_lines: t.Optional[int] = None,
         devel: bool = False,
+        debug: bool = False,
         dry_run: bool = False,
         namespace: t.Optional[str] = None,
         no_hooks: bool = False,
@@ -381,6 +382,8 @@ class Command:
             command.extend(["--context", context_lines])
         if devel:
             command.append("--devel")
+        if debug:
+            command.append("--debug")
         if dry_run:
             command.append("--dry-run")
         if namespace:
@@ -514,6 +517,7 @@ class Command:
         create_namespace: bool = True,
         description: t.Optional[str] = None,
         devel: bool = False,
+        debug: bool = False,
         dry_run: bool = False,
         force: bool = False,
         namespace: t.Optional[str] = None,
@@ -551,6 +555,8 @@ class Command:
             command.extend(["--description", description])
         if devel:
             command.append("--devel")
+        if debug:
+            command.append("--debug")
         if dry_run:
             command.append("--dry-run")
         if force:
@@ -622,6 +628,7 @@ class Command:
         chart_ref: t.Union[pathlib.Path, str],
         *,
         devel: bool = False,
+        debug: bool = False,
         repo: t.Optional[str] = None,
         version: t.Optional[str] = None
     ) -> pathlib.Path:
@@ -635,6 +642,8 @@ class Command:
         command = ["pull", chart_ref, "--destination", destination, "--untar"]
         if devel:
             command.append("--devel")
+        if debug:
+            command.append("--debug")
         if repo:
             command.extend(["--repo", repo])
         if version:
@@ -686,6 +695,7 @@ class Command:
         *,
         cleanup_on_fail: bool = False,
         dry_run: bool = False,
+        debug: bool = False,
         force: bool = False,
         namespace: t.Optional[str] = None,
         no_hooks: bool = False,
@@ -709,6 +719,8 @@ class Command:
         ])
         if cleanup_on_fail:
             command.append("--cleanup-on-fail")
+        if debug:
+            command.append("--debug")
         if dry_run:
             command.append("--dry-run")
         if force:
@@ -729,6 +741,7 @@ class Command:
         *,
         all_versions: bool = False,
         devel: bool = False,
+        debug: bool = False,
         version_constraints: t.Optional[str] = None
     ) -> t.Iterable[t.Dict[str, t.Any]]:
         """
@@ -741,6 +754,8 @@ class Command:
             command.append("--versions")
         if devel:
             command.append("--devel")
+        if debug:
+            command.append("--debug")
         if version_constraints:
             command.extend(["--version", version_constraints])
         return json.loads(await self.run(command))
@@ -750,6 +765,7 @@ class Command:
         chart_ref: t.Union[pathlib.Path, str],
         *,
         devel: bool = False,
+        debug: bool = False,
         repo: t.Optional[str] = None,
         version: t.Optional[str] = None
     ) -> t.Dict[str, t.Any]:
@@ -759,6 +775,8 @@ class Command:
         command = ["show", "chart", chart_ref]
         if devel:
             command.append("--devel")
+        if debug:
+            command.append("--debug")
         if repo:
             command.extend(["--repo", repo])
         if version:
@@ -890,6 +908,7 @@ class Command:
         values: t.Optional[t.Dict[str, t.Any]] = None,
         *,
         devel: bool = False,
+        debug: bool = False,
         include_crds: bool = False,
         is_upgrade: bool = False,
         namespace: t.Optional[str] = None,
@@ -910,6 +929,8 @@ class Command:
         ]
         if devel:
             command.append("--devel")
+        if debug:
+            command.append("--debug")
         if is_upgrade:
             command.append("--is-upgrade")
         if namespace:
@@ -930,6 +951,7 @@ class Command:
         release_name: str,
         *,
         dry_run: bool = False,
+        debug: bool = False,
         keep_history: bool = False,
         namespace: t.Optional[str] = None,
         no_hooks: bool = False,
@@ -947,6 +969,8 @@ class Command:
         ]
         if dry_run:
             command.append("--dry-run")
+        if debug:
+            command.append("--debug")
         if keep_history:
             command.append("--keep-history")
         if namespace:


### PR DESCRIPTION
* Add in the `--debug` command to all helm compatible ones when the `--devel` flag was present or after manual checking of helm CLI support
* Adds in debugging capability as commented on issue https://github.com/azimuth-cloud/pyhelm3/issues/19
* Tested by building using setup.py